### PR TITLE
Add support for RegExp on $in and others

### DIFF
--- a/lib/lodash-query.js
+++ b/lib/lodash-query.js
@@ -8,9 +8,14 @@ The aim of the project is to provide a simple, well tested, way of filtering dat
  */
 var QueryBuilder, addToQuery, buildQuery, createUtils, expose, findOne, i, key, len, makeTest, multipleConditions, parseGetter, parseParamType, parseQuery, parseSubQuery, performQuery, performQuerySingle, ref, root, runQuery, score, single, testModelAttribute, testQueryValue, underscoreReplacement, utils,
     slice = [].slice,
-    indexOf = [].indexOf || function(item) {
+    indexOf = function(item) {
         for (var i = 0, l = this.length; i < l; i++) {
-            if (i in this && this[i] === item) return i;
+            if (this[i].constructor.name === 'RegExp') {
+              if (i in this && this[i].test(item)) return i;
+            }
+            else {
+              if (i in this && this[i] === item) return i;
+            }
         }
         return -1;
     },

--- a/test/lodash.js
+++ b/test/lodash.js
@@ -176,6 +176,16 @@
             });
             return assert.equal(result.length, 2);
         });
+        it("$in operator with RegExp", function() {
+            var a, result;
+            a = create();
+            result = _.query(a, {
+                title: {
+                    $in: [new RegExp("hOme", 'i'), "About"] 
+                }
+            });
+            return assert.equal(result.length, 2);
+        });
         it("$in operator with wrong query value", function() {
             var a;
             a = create();

--- a/test/no_mixin.js
+++ b/test/no_mixin.js
@@ -176,6 +176,16 @@
             });
             return assert.equal(result.length, 2);
         });
+        it("$in operator with RegExp", function() {
+            var a, result;
+            a = create();
+            result = _.query(a, {
+                title: {
+                    $in: [new RegExp("hOme", 'i'), "About"] 
+                }
+            });
+            return assert.equal(result.length, 2);
+        });
         it("$in operator with wrong query value", function() {
             var a;
             a = create();

--- a/test/test.js
+++ b/test/test.js
@@ -176,6 +176,16 @@
             });
             return assert.equal(result.length, 2);
         });
+        it("$in operator with RegExp", function() {
+            var a, result;
+            a = create();
+            result = _.query(a, {
+                title: {
+                    $in: [new RegExp("hOme", 'i'), "About"] 
+                }
+            });
+            return assert.equal(result.length, 2);
+        });
         it("$in operator with wrong query value", function() {
             var a;
             a = create();


### PR DESCRIPTION
Add support for RegExp on $in and others so

`{ name: { $in: [ new RegExp("JohN", "i") ] } }`

wil match `John` in `[ "Alex", "John" ]`